### PR TITLE
Use nativeToJsBridgeMode ONLINE_EVENT.

### DIFF
--- a/www/SpenPlugin.js
+++ b/www/SpenPlugin.js
@@ -1,5 +1,5 @@
 var SpenPlugin = function() {
-	cordova.exec.setNativeToJsBridgeMode(cordova.exec.nativeToJsModes.PRIVATE_API);
+	cordova.exec.setNativeToJsBridgeMode(cordova.exec.nativeToJsModes.ONLINE_EVENT);
 };
 
 SpenPlugin.prototype.addEvents = function() {


### PR DESCRIPTION
Some devices without spen fail badly with the PRIVATE_API mode. I don't
know the reason, but this change fixed my problem.
